### PR TITLE
[BUGFIX] Fix duplicate php-cs-fixer execution in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches: [ main, develop, feature/** ]
   pull_request:
     branches: [ main, develop ]
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -3,8 +3,6 @@ name: Code Quality
 on:
   push:
     branches: [ main, develop, feature/** ]
-  pull_request:
-    branches: [ main, develop ]
 
 jobs:
   php-cs-fixer:


### PR DESCRIPTION
Fixes #207

## Summary
- `ci.yml` now triggers on `pull_request` only (removed `push` trigger)
- `code-quality.yml` now triggers on `push` only (removed `pull_request` trigger)

This eliminates duplicate execution of php-cs-fixer (and all other quality checks) that occurred when both workflows fired on the same event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)